### PR TITLE
Use rusty idioms in new_from_file

### DIFF
--- a/packages/ui/src/document.rs
+++ b/packages/ui/src/document.rs
@@ -1,4 +1,4 @@
-use std::{fs::File, io::Read, io::Result};
+use std::io::Result;
 use std::path::Path;
 
 /// In-memory representation of a pcl-demo document.
@@ -10,8 +10,9 @@ impl Document {
 
     /// Returns the in-memory representation of the pcl-demo document at `p`.
     pub fn new_from_file<P: AsRef<Path>>(p: P) -> Result<Self> {
-        let mut r = Document { html: String::new() };
-        File::open(p)?.read_to_string(&mut r.html).map(|_| r)
+        Ok(Document {
+          html: std::fs::read_to_string(p)?
+        })
     }
 
     /// Returns the HTML to render `self`.


### PR DESCRIPTION
We can make `new_from_file` more succinct and unambiguous with the `?` operator.